### PR TITLE
fix: Handle misformed error response (without `stack`)

### DIFF
--- a/src/handle.ts
+++ b/src/handle.ts
@@ -8,7 +8,7 @@ export const handle = (err: any) => {
   try {
     if (!err) err = new Error('no error?')
     if (err.message === 'SIGINT') process.exit(1)
-    let stack = clean(err.stack, {pretty: true})
+    let stack = clean(err.stack || '', {pretty: true})
     let message = stack
     if (err.oclif && typeof err.render === 'function') message = err.render()
     if (message) console.error(message)

--- a/test/handle.test.ts
+++ b/test/handle.test.ts
@@ -40,7 +40,7 @@ describe('handle', () => {
   .stderr()
   .finally(() => delete process.exitCode)
   .it('handles a badly formed error object', () => {
-    handle({ status: 400 })
+    handle({status: 400})
     expect(process.exitCode).to.equal(1)
   })
 

--- a/test/handle.test.ts
+++ b/test/handle.test.ts
@@ -39,6 +39,14 @@ describe('handle', () => {
   fancy
   .stderr()
   .finally(() => delete process.exitCode)
+  .it('handles a badly formed error object', ctx => {
+    handle({ status: 400 })
+    expect(process.exitCode).to.equal(1)
+  })
+
+  fancy
+  .stderr()
+  .finally(() => delete process.exitCode)
   .it('shows a cli error', ctx => {
     handle(new CLIError('x'))
     expect(ctx.stderr).to.equal(` ${x}   Error: x\n`)

--- a/test/handle.test.ts
+++ b/test/handle.test.ts
@@ -39,7 +39,7 @@ describe('handle', () => {
   fancy
   .stderr()
   .finally(() => delete process.exitCode)
-  .it('handles a badly formed error object', ctx => {
+  .it('handles a badly formed error object', () => {
     handle({ status: 400 })
     expect(process.exitCode).to.equal(1)
   })


### PR DESCRIPTION
Very small fix.

The `clean-stack` module always expects a string to be passed in as the first argument, otherwise, it falls apart trying to run `.replace()` on `undefined`.

I understand that this module also assumes that it will receive nothing or a properly formatted Error object, but I've run into a situation where because of another third party module (`bitbucket-api-v2`), it receives a plain object and not an error object. This small fix just ensures that the error gets passed along without issues.