### PR TITLE
Fixup for wrapping errors in CLIError constructor

### DIFF
--- a/src/errors/cli.ts
+++ b/src/errors/cli.ts
@@ -13,17 +13,20 @@ export class CLIError extends Error {
   originalStack?: string
 
   constructor(error: string | Error, options: {code?: string, exit?: number | false} = {}) {
+    const defaultExit = 2
     if (error instanceof Error) {
       super(error.message)
       this.oclif = (error as any).oclif || {}
-      this.originalStack = error.stack || undefined
+      this.oclif.exit = options.exit !== undefined ? options.exit :
+          this.oclif.exit !== undefined ? this.oclif.exit : defaultExit
+      this.originalStack = (error as any).originalStack || error.stack
+      this.code = options.code !== undefined ? options.code : (error as any).code
     } else {
       super(error)
       this.oclif = {}
-      this.originalStack = undefined
+      this.oclif.exit = options.exit !== undefined ? options.exit : defaultExit
+      this.code = options.code
     }
-    this.oclif.exit = options.exit === undefined ? 2 : options.exit
-    this.code = options.code
   }
 
   get stack(): string {

--- a/src/errors/cli.ts
+++ b/src/errors/cli.ts
@@ -10,22 +10,25 @@ import {config} from '../config'
 export class CLIError extends Error {
   oclif: any
   code?: string
+  originalStack?: string
 
   constructor(error: string | Error, options: {code?: string, exit?: number | false} = {}) {
-    const addExitCode = (error: any) => {
-      error.oclif = error.oclif || {}
-      error.oclif.exit = options.exit === undefined ? 2 : options.exit
-      return error
+    if (error instanceof Error) {
+      super(error.message)
+      this.oclif = (error as any).oclif || {}
+      this.originalStack = error.stack || undefined
+    } else {
+      super(error)
+      this.oclif = {}
+      this.originalStack = undefined
     }
-    if (error instanceof Error) return addExitCode(error as any)
-    super(error)
-    addExitCode(this)
+    this.oclif.exit = options.exit === undefined ? 2 : options.exit
     this.code = options.code
   }
 
   get stack(): string {
     const clean: typeof Clean = require('clean-stack')
-    return clean(super.stack!, {pretty: true})
+    return clean(this.originalStack ? this.originalStack : super.stack!, {pretty: true})
   }
 
   render(): string {


### PR DESCRIPTION
This makes it so that `this.error(new Error(...))` within oclif
command `run()` prints nicely, and without a stack trace in
non-debug mode.