### PR TITLE
fix: export pretty printable error interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {CLIError, addOclifExitCode, OclifError} from './errors/cli'
 import {ExitError} from './errors/exit'
 import prettyPrint, {PrettyPrintableError, applyPrettyPrintOptions} from './errors/pretty-print'
 
-export {prettyPrint}
+export {PrettyPrintableError}
 
 export function exit(code = 0): never {
   throw new ExitError(code)


### PR DESCRIPTION
The export in #27 should have been `PrettyPrintableError` for `oclif/command` and consumers to have access to this type.