### PR TITLE
fix: missing stream.getWindowSize error

### DIFF
--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,5 +1,5 @@
 function termwidth(stream: any): number {
-  if (!stream.isTTY) {
+  if (!stream.isTTY || !stream.getWindowSize) {
     return 80
   }
   const width = stream.getWindowSize()[0]


### PR DESCRIPTION
In macos, got error: `TypeError: stream.getWindowSize is not a function.`
This error happens by simply importing the module.
