### PR TITLE
fix: just set exit code, do not force termination

### DIFF
--- a/src/handle.ts
+++ b/src/handle.ts
@@ -9,7 +9,7 @@ import {OclifError, CLIError} from './errors/cli'
 export const handle = (err: Error & Partial<PrettyPrintableError> & Partial<OclifError>) => {
   try {
     if (!err) err = new CLIError('no error?')
-    if (err.message === 'SIGINT') process.exit(1)
+    if (err.message === 'SIGINT') process.exitCode = 1
 
     const shouldPrint = !(err instanceof ExitError)
     const pretty = prettyPrint(err)
@@ -27,12 +27,12 @@ export const handle = (err: Error & Partial<PrettyPrintableError> & Partial<Ocli
       }
 
       config.errorLogger.flush()
-      .then(() => process.exit(exitCode))
+      .then(() => process.exitCode = exitCode)
       .catch(console.error)
-    } else process.exit(exitCode)
+    } else process.exitCode = exitCode
   } catch (error) {
     console.error(err.stack)
     console.error(error.stack)
-    process.exit(1)
+    process.exitCode = 1
   }
 }


### PR DESCRIPTION
Oclif should wait for other tasks to complete gracefully, and not force them to exit